### PR TITLE
Enable port number directly type in and fix http request bug

### DIFF
--- a/OpenHardwareMonitor/UI/InterfacePortForm.Designer.cs
+++ b/OpenHardwareMonitor/UI/InterfacePortForm.Designer.cs
@@ -122,7 +122,7 @@
             0,
             0});
             this.portNumericUpDn.Minimum = new decimal(new int[] {
-            8080,
+            1,
             0,
             0,
             0});

--- a/OpenHardwareMonitor/Utilities/HttpServer.cs
+++ b/OpenHardwareMonitor/Utilities/HttpServer.cs
@@ -199,7 +199,10 @@ public class HttpServer
     {
         if (node is SensorNode sNode)
         {
-            if (sNode.Sensor.Identifier.ToString() == id)
+            string decodedSensorId = HttpUtility.UrlDecode(sNode.Sensor.Identifier.ToString());
+            string decodedId = HttpUtility.UrlDecode(id);
+            //if (sNode.Sensor.Identifier.ToString() == id)
+            if (decodedSensorId == decodedId)
                 return sNode;
         }
 


### PR DESCRIPTION
1. The port number up/down control was limited by minimum number of 8080, so when user directly type in the number, it would be corrected to 20000.
2. If user want to access a sensor with character like '{' or '}' in the id string, the web server can not reponse correcly.
  for example: 
http://127.0.0.1:8088/Sensor?action=Get&id=/nic/%7B3610E5A6-B1A2-46DE-ABCD-CA9D97BDE218%7D/throughput/7