### PR TITLE
Fix bug of http response error when sensor id contains URL encoded chars

### DIFF
--- a/OpenHardwareMonitor/Utilities/HttpServer.cs
+++ b/OpenHardwareMonitor/Utilities/HttpServer.cs
@@ -199,7 +199,7 @@ public class HttpServer
     {
         if (node is SensorNode sNode)
         {
-            if (sNode.Sensor.Identifier.ToString() == id)
+            if (HttpUtility.UrlDecode(sNode.Sensor.Identifier.ToString()) == HttpUtility.UrlDecode(id))
                 return sNode;
         }
 


### PR DESCRIPTION
http requests such as:
http://localhost:8088/Sensor?action=Get&id=/nic/%7B39C36B8E-C795-4E9E-A7DF-7F1E2F8064CD%7D/load/1
will result an error response.
<img width="1472" height="300" alt="image" src="https://github.com/user-attachments/assets/e29e1110-4732-4f3a-af09-b572756d547d" />

Fixed by add URL decode function before comparing id and sensor nodes:
<img width="1512" height="212" alt="image" src="https://github.com/user-attachments/assets/5aa5d347-4fc0-45f2-b712-5bbf6eb5c4ad" />
